### PR TITLE
feat: Implement interactive 'What-If' exam score simulator

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -73,6 +73,7 @@
             <button data-tab="study_habits" class="tab-button text-sm md:text-base px-4 py-2 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md">Hábitos de Estudo</button>
             <button data-tab="lifestyle" class="tab-button text-sm md:text-base px-4 py-2 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md">Estilo de Vida</button>
             <button data-tab="predictive" class="tab-button text-sm md:text-base px-4 py-2 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md">Análise Preditiva</button>
+            <button data-tab="simulator" class="tab-button text-sm md:text-base px-4 py-2 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md">Simulador</button>
             <button data-tab="conclusions" class="tab-button text-sm md:text-base px-4 py-2 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md">Conclusões</button>
         </nav>
 
@@ -218,6 +219,106 @@
                 </div>
             </section>
 
+            <section id="simulator" class="tab-content hidden bg-white p-6 rounded-lg shadow-lg">
+                <h2 class="text-2xl font-semibold text-teal-600 mb-4">Simulador Interativo 'What-If'</h2>
+                <p class="mb-6 text-slate-600">Experimente com diferentes hábitos e características para ver uma estimativa da pontuação no exame, baseada em um modelo de Regressão Linear. Lembre-se que este é um modelo simplificado para interatividade web e os resultados podem diferir do modelo Random Forest mais preciso discutido na análise principal.</p>
+            
+                <div id="simulator_inputs" class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6 mb-6">
+                    <!-- Numerical Inputs -->
+                    <div>
+                        <label for="sim_age" class="block text-sm font-medium text-slate-700 mb-1">Idade (anos): <span id="sim_age_value" class="font-semibold text-teal-700">20</span></label>
+                        <input type="range" id="sim_age" name="sim_age" min="17" max="24" step="1" value="20" class="w-full h-2 bg-slate-200 rounded-lg appearance-none cursor-pointer accent-teal-600">
+                    </div>
+                    <div>
+                        <label for="sim_study_hours_per_day" class="block text-sm font-medium text-slate-700 mb-1">Horas de Estudo/Dia: <span id="sim_study_hours_per_day_value" class="font-semibold text-teal-700">4.0</span></label>
+                        <input type="range" id="sim_study_hours_per_day" name="sim_study_hours_per_day" min="0" max="9" step="0.1" value="4" class="w-full h-2 bg-slate-200 rounded-lg appearance-none cursor-pointer accent-teal-600">
+                    </div>
+                    <div>
+                        <label for="sim_social_media_hours" class="block text-sm font-medium text-slate-700 mb-1">Horas em Mídias Sociais/Dia: <span id="sim_social_media_hours_value" class="font-semibold text-teal-700">2.0</span></label>
+                        <input type="range" id="sim_social_media_hours" name="sim_social_media_hours" min="0" max="6" step="0.1" value="2" class="w-full h-2 bg-slate-200 rounded-lg appearance-none cursor-pointer accent-teal-600">
+                    </div>
+                    <div>
+                        <label for="sim_netflix_hours" class="block text-sm font-medium text-slate-700 mb-1">Horas em Streaming/Dia: <span id="sim_netflix_hours_value" class="font-semibold text-teal-700">2.0</span></label>
+                        <input type="range" id="sim_netflix_hours" name="sim_netflix_hours" min="0" max="6" step="0.1" value="2" class="w-full h-2 bg-slate-200 rounded-lg appearance-none cursor-pointer accent-teal-600">
+                    </div>
+                    <div>
+                        <label for="sim_attendance_percentage" class="block text-sm font-medium text-slate-700 mb-1">Frequência nas Aulas (%): <span id="sim_attendance_percentage_value" class="font-semibold text-teal-700">80</span></label>
+                        <input type="range" id="sim_attendance_percentage" name="sim_attendance_percentage" min="50" max="100" step="1" value="80" class="w-full h-2 bg-slate-200 rounded-lg appearance-none cursor-pointer accent-teal-600">
+                    </div>
+                    <div>
+                        <label for="sim_sleep_hours" class="block text-sm font-medium text-slate-700 mb-1">Horas de Sono/Noite: <span id="sim_sleep_hours_value" class="font-semibold text-teal-700">7.0</span></label>
+                        <input type="range" id="sim_sleep_hours" name="sim_sleep_hours" min="4" max="10" step="0.1" value="7" class="w-full h-2 bg-slate-200 rounded-lg appearance-none cursor-pointer accent-teal-600">
+                    </div>
+                    <div>
+                        <label for="sim_exercise_frequency" class="block text-sm font-medium text-slate-700 mb-1">Frequência de Exercícios (dias/semana): <span id="sim_exercise_frequency_value" class="font-semibold text-teal-700">3</span></label>
+                        <input type="range" id="sim_exercise_frequency" name="sim_exercise_frequency" min="0" max="7" step="1" value="3" class="w-full h-2 bg-slate-200 rounded-lg appearance-none cursor-pointer accent-teal-600">
+                    </div>
+                    <div>
+                        <label for="sim_mental_health_rating" class="block text-sm font-medium text-slate-700 mb-1">Saúde Mental (1-10): <span id="sim_mental_health_rating_value" class="font-semibold text-teal-700">5</span></label>
+                        <input type="range" id="sim_mental_health_rating" name="sim_mental_health_rating" min="1" max="10" step="1" value="5" class="w-full h-2 bg-slate-200 rounded-lg appearance-none cursor-pointer accent-teal-600">
+                    </div>
+            
+                    <!-- Categorical Inputs -->
+                    <div>
+                        <label for="sim_gender" class="block text-sm font-medium text-slate-700">Gênero:</label>
+                        <select id="sim_gender" name="sim_gender" class="mt-1 block w-full p-2 border border-slate-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-teal-500 focus:border-teal-500 sm:text-sm">
+                            <option value="Female">Feminino</option>
+                            <option value="Male">Masculino</option>
+                            <option value="Other">Outro</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label for="sim_part_time_job" class="block text-sm font-medium text-slate-700">Trabalho em Meio Período?</label>
+                        <select id="sim_part_time_job" name="sim_part_time_job" class="mt-1 block w-full p-2 border border-slate-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-teal-500 focus:border-teal-500 sm:text-sm">
+                            <option value="No">Não</option>
+                            <option value="Yes">Sim</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label for="sim_diet_quality" class="block text-sm font-medium text-slate-700">Qualidade da Dieta:</label>
+                        <select id="sim_diet_quality" name="sim_diet_quality" class="mt-1 block w-full p-2 border border-slate-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-teal-500 focus:border-teal-500 sm:text-sm">
+                            <option value="Poor">Ruim</option>
+                            <option value="Fair" selected>Razoável</option>
+                            <option value="Good">Boa</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label for="sim_parental_education_level" class="block text-sm font-medium text-slate-700">Nível Educacional dos Pais:</label>
+                        <select id="sim_parental_education_level" name="sim_parental_education_level" class="mt-1 block w-full p-2 border border-slate-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-teal-500 focus:border-teal-500 sm:text-sm">
+                            <option value="None">Nenhum</option>
+                            <option value="High School" selected>Ensino Médio</option>
+                            <option value="Bachelor">Graduação</option>
+                            <option value="Master">Mestrado/Doutorado</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label for="sim_internet_quality" class="block text-sm font-medium text-slate-700">Qualidade da Internet em Casa:</label>
+                        <select id="sim_internet_quality" name="sim_internet_quality" class="mt-1 block w-full p-2 border border-slate-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-teal-500 focus:border-teal-500 sm:text-sm">
+                            <option value="Poor">Ruim</option>
+                            <option value="Average" selected>Média</option>
+                            <option value="Good">Boa</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label for="sim_extracurricular_participation" class="block text-sm font-medium text-slate-700">Participa de Atividades Extracurriculares?</label>
+                        <select id="sim_extracurricular_participation" name="sim_extracurricular_participation" class="mt-1 block w-full p-2 border border-slate-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-teal-500 focus:border-teal-500 sm:text-sm">
+                            <option value="No" selected>Não</option>
+                            <option value="Yes">Sim</option>
+                        </select>
+                    </div>
+                </div>
+            
+                <div class="mt-8 text-center">
+                    <button id="sim_predict_button" class="bg-teal-600 hover:bg-teal-700 text-white font-semibold py-3 px-8 rounded-lg shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-opacity-75 transition duration-150 ease-in-out text-lg">
+                        Prever Pontuação
+                    </button>
+                </div>
+            
+                <div id="sim_predicted_score_container" class="mt-8 p-6 bg-orange-100 rounded-lg shadow text-center">
+                    <h3 id="sim_predicted_score" class="text-2xl md:text-3xl font-bold text-teal-700">Pontuação Estimada: --</h3>
+                </div>
+            </section>
+
             <section id="conclusions" class="tab-content hidden bg-white p-6 rounded-lg shadow-lg">
                 <h2 class="text-2xl font-semibold text-teal-600 mb-4">7. Principais Descobertas, Conclusões e Próximos Passos</h2>
                 <p class="mb-4">Esta análise do dataset sintético "Student Habits vs Academic Performance" permitiu aplicar diversas técnicas de ciência de dados. As descobertas (simuladas) sugerem que hábitos de estudo, bem-estar e saúde mental estão associados ao desempenho acadêmico.</p>
@@ -341,7 +442,8 @@
                         if (target === 'study_habits') initStudyHabitsCharts();
                         if (target === 'lifestyle') initLifestyleCharts();
                         if (target === 'predictive') initPredictiveCharts();
-
+                        // Note: Simulator tab content is static HTML for now, no specific JS init on tab click needed yet.
+                        // if (target === 'simulator') ; 
                     } else {
                         content.classList.add('hidden');
                     }
@@ -685,6 +787,155 @@
             initOverviewCharts(); 
         });
 
+        // --- Interactive Simulator Logic ---
+        document.addEventListener('DOMContentLoaded', () => {
+            const simulatorInputs = {
+                age: document.getElementById('sim_age'),
+                study_hours_per_day: document.getElementById('sim_study_hours_per_day'),
+                social_media_hours: document.getElementById('sim_social_media_hours'),
+                netflix_hours: document.getElementById('sim_netflix_hours'),
+                attendance_percentage: document.getElementById('sim_attendance_percentage'),
+                sleep_hours: document.getElementById('sim_sleep_hours'),
+                exercise_frequency: document.getElementById('sim_exercise_frequency'),
+                mental_health_rating: document.getElementById('sim_mental_health_rating'),
+                gender: document.getElementById('sim_gender'),
+                part_time_job: document.getElementById('sim_part_time_job'),
+                diet_quality: document.getElementById('sim_diet_quality'),
+                parental_education_level: document.getElementById('sim_parental_education_level'),
+                internet_quality: document.getElementById('sim_internet_quality'),
+                extracurricular_participation: document.getElementById('sim_extracurricular_participation')
+            };
+
+            const simulatorValueSpans = {
+                age: document.getElementById('sim_age_value'),
+                study_hours_per_day: document.getElementById('sim_study_hours_per_day_value'),
+                social_media_hours: document.getElementById('sim_social_media_hours_value'),
+                netflix_hours: document.getElementById('sim_netflix_hours_value'),
+                attendance_percentage: document.getElementById('sim_attendance_percentage_value'),
+                sleep_hours: document.getElementById('sim_sleep_hours_value'),
+                exercise_frequency: document.getElementById('sim_exercise_frequency_value'),
+                mental_health_rating: document.getElementById('sim_mental_health_rating_value')
+            };
+
+            const predictButton = document.getElementById('sim_predict_button');
+            const predictedScoreDisplay = document.getElementById('sim_predicted_score');
+
+            // 1. Update slider value displays
+            for (const key in simulatorValueSpans) {
+                if (simulatorInputs[key] && simulatorInputs[key].type === 'range') {
+                    simulatorInputs[key].addEventListener('input', (event) => {
+                        simulatorValueSpans[key].textContent = parseFloat(event.target.value).toFixed(simulatorInputs[key].step >= 1 ? 0 : 1);
+                    });
+                }
+            }
+            
+            // 2. Prediction Logic
+            // These parameters MUST match the output from the Jupyter Notebook 04_Predictive_Modeling.ipynb
+            const MODEL_PARAMS = {
+                INTERCEPT: 70.10991347734646,
+                COEFFICIENTS: {
+                    "num__age": 0.03003910828682918,
+                    "num__study_hours_per_day": 2.8088997679982917,
+                    "num__social_media_hours": -0.6177247000890449,
+                    "num__netflix_hours": -0.01800038330320132,
+                    "num__attendance_percentage": 0.1608070339782499,
+                    "num__sleep_hours": 0.5195111697000953,
+                    "num__exercise_frequency": 0.13017761486412497,
+                    "num__mental_health_rating": 1.0010904168087196,
+                    "cat__gender_Male": -0.010576186457078907,
+                    "cat__gender_Other": 0.1915259483156042,
+                    "cat__part_time_job_Yes": -0.2908031486586012,
+                    "cat__diet_quality_Good": 0.8722640001136023,
+                    "cat__diet_quality_Poor": -1.0001240066034222,
+                    "cat__parental_education_level_High School": 0.3708088440788841,
+                    "cat__parental_education_level_Master": 0.9912461880851497,
+                    "cat__parental_education_level_None": 0.02927333608068159,
+                    "cat__internet_quality_Good": 1.2905420020819505,
+                    "cat__internet_quality_Poor": -1.448376691689821,
+                    "cat__extracurricular_participation_Yes": 0.4140934890852299
+                },
+                NUMERICAL_PARAMS: {
+                    "age": { mean: 20.5420, std_dev: 2.274175 }, // Corrected from notebook image
+                    "study_hours_per_day": { mean: 4.5150, std_dev: 2.594885 }, // Corrected
+                    "social_media_hours": { mean: 2.4820, std_dev: 1.720061 }, // Corrected
+                    "netflix_hours": { mean: 2.5190, std_dev: 1.708519 },      // Corrected
+                    "attendance_percentage": { mean: 74.9980, std_dev: 14.639490 }, // Corrected
+                    "sleep_hours": { mean: 7.0280, std_dev: 1.713537 },       // Corrected
+                    "exercise_frequency": { mean: 2.5030, std_dev: 1.720786 }, // Corrected
+                    "mental_health_rating": { mean: 5.5000, std_dev: 2.868714 } // Corrected (mean was 5.5, not 5.5 mental_health_rating)
+                },
+                CATEGORICAL_MAP: {
+                    "gender": { categories: ["Female", "Male", "Other"], dropped: "Female" },
+                    "part_time_job": { categories: ["No", "Yes"], dropped: "No" },
+                    "diet_quality": { categories: ["Fair", "Good", "Poor"], dropped: "Fair" }, // Order from notebook: Fair, Good, Poor. 'Fair' is first.
+                    "parental_education_level": { categories: ["Bachelor", "High School", "Master", "None"], dropped: "Bachelor" }, // Order: Bachelor, High School, Master, None. 'Bachelor' is first.
+                    "internet_quality": { categories: ["Average", "Good", "Poor"], dropped: "Average" }, // Order: Average, Good, Poor. 'Average' is first.
+                    "extracurricular_participation": { categories: ["No", "Yes"], dropped: "No" }
+                },
+                FINAL_FEATURE_ORDER: [
+                    "num__age", "num__study_hours_per_day", "num__social_media_hours", "num__netflix_hours",
+                    "num__attendance_percentage", "num__sleep_hours", "num__exercise_frequency", "num__mental_health_rating",
+                    "cat__gender_Male", "cat__gender_Other", "cat__part_time_job_Yes",
+                    "cat__diet_quality_Good", "cat__diet_quality_Poor",
+                    "cat__parental_education_level_High School", "cat__parental_education_level_Master", "cat__parental_education_level_None",
+                    "cat__internet_quality_Good", "cat__internet_quality_Poor",
+                    "cat__extracurricular_participation_Yes"
+                ]
+            };
+
+            function predictScore() {
+                const processedFeatures = {};
+
+                // Process Numerical Features
+                for (const key in MODEL_PARAMS.NUMERICAL_PARAMS) {
+                    const value = parseFloat(simulatorInputs[key].value);
+                    const params = MODEL_PARAMS.NUMERICAL_PARAMS[key];
+                    processedFeatures[`num__${key}`] = (value - params.mean) / params.std_dev;
+                }
+
+                // Process Categorical Features
+                for (const key in MODEL_PARAMS.CATEGORICAL_MAP) {
+                    const selectedValue = simulatorInputs[key].value;
+                    const mapInfo = MODEL_PARAMS.CATEGORICAL_MAP[key];
+                    
+                    mapInfo.categories.forEach(category => {
+                        if (category === mapInfo.dropped) return; // Skip the dropped category
+
+                        const featureName = `cat__${key}_${category}`;
+                        processedFeatures[featureName] = (selectedValue === category) ? 1 : 0;
+                    });
+                }
+                
+                // Calculate Prediction
+                let prediction = MODEL_PARAMS.INTERCEPT;
+                MODEL_PARAMS.FINAL_FEATURE_ORDER.forEach(featureName => {
+                    const featureValue = processedFeatures[featureName];
+                    const coefficient = MODEL_PARAMS.COEFFICIENTS[featureName];
+                    
+                    if (typeof featureValue === 'undefined' || typeof coefficient === 'undefined') {
+                        console.warn(`Warning: Missing value or coefficient for feature: ${featureName}. Value: ${featureValue}, Coeff: ${coefficient}`);
+                         // If a feature somehow wasn't processed or has no coefficient, it won't contribute.
+                         // This check helps in debugging potential mismatches in feature names.
+                    } else {
+                        prediction += featureValue * coefficient;
+                    }
+                });
+
+                // Display Prediction (clamped between 0 and 100, as exam scores usually are)
+                const finalScore = Math.max(0, Math.min(100, prediction));
+                predictedScoreDisplay.textContent = `Pontuação Estimada: ${finalScore.toFixed(2)}`;
+            }
+
+            // 3. Attach Event Listener
+            if (predictButton) {
+                predictButton.addEventListener('click', predictScore);
+            } else {
+                console.error("Predict button not found!");
+            }
+            
+            // Initialize prediction on page load with default values
+             predictScore();
+        });
     </script>
 </body>
 </html>

--- a/notebooks/04_Predictive_Modeling.ipynb
+++ b/notebooks/04_Predictive_Modeling.ipynb
@@ -31,6 +31,332 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Linear Regression Model and Preprocessing Details for JavaScript Implementation\n",
+    "\n",
+    "The following cells extract and display the trained parameters from the Linear Regression model (`lr_pipeline`) and the preprocessing steps. This information can be used as a reference for a JavaScript implementation of the same model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Extracted Model and Preprocessor Objects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Retrieve the trained LinearRegression model and ColumnTransformer preprocessor\n",
+    "lr_model = lr_pipeline.named_steps['regressor']\n",
+    "preprocessor_from_pipeline = lr_pipeline.named_steps['preprocessor']\n",
+    "\n",
+    "print(\"LinearRegression model retrieved:\", lr_model)\n",
+    "print(\"ColumnTransformer preprocessor retrieved:\", preprocessor_from_pipeline)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Linear Regression: Intercept and Coefficients"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Linear Regression Intercept (Bias):\")\n",
+    "print(lr_model.intercept_)\n",
+    "\n",
+    "print(\"\\nLinear Regression Coefficients (Weights):\")\n",
+    "print(lr_model.coef_)\n",
+    "\n",
+    "print(\"\\nFeature names corresponding to the coefficients (after all preprocessing):\")\n",
+    "final_feature_names = preprocessor_from_pipeline.get_feature_names_out()\n",
+    "print(final_feature_names)\n",
+    "\n",
+    "print(\"\\nCoefficients with their corresponding feature names:\")\n",
+    "for feature, coef in zip(final_feature_names, lr_model.coef_):\n",
+    "    print(f\"{feature}: {coef:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The **Intercept** is the value of the target variable when all features are zero (or at their reference levels for categorical features). \n",
+    "The **Coefficients** represent the change in the target variable for a one-unit change in the corresponding feature, holding all other features constant. For scaled numerical features, this means a one-unit change in the scaled value. For one-hot encoded categorical features, it's the change relative to the dropped category."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Preprocessing Details: Numerical Features (StandardScaler)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "numerical_transformer_from_pipeline = preprocessor_from_pipeline.named_transformers_['num']\n",
+    "# Original numerical features are stored in the ColumnTransformer's 'transformers_' list\n",
+    "original_numerical_features = [t[2] for t in preprocessor_from_pipeline.transformers if t[0] == 'num'][0]\n",
+    "\n",
+    "print(\"Numerical Features Scaled:\", original_numerical_features)\n",
+    "print(\"\\nStandardScaler Mean (for each numerical feature):\")\n",
+    "print(numerical_transformer_from_pipeline.mean_)\n",
+    "print(\"\\nStandardScaler Scale (Standard Deviation, for each numerical feature):\")\n",
+    "print(numerical_transformer_from_pipeline.scale_)\n",
+    "\n",
+    "print(\"\\nNumerical features with their scaling parameters (mean, std_dev):\")\n",
+    "for i, feature_name in enumerate(original_numerical_features):\n",
+    "    print(f\"{feature_name}: mean={numerical_transformer_from_pipeline.mean_[i]:.4f}, std_dev={numerical_transformer_from_pipeline.scale_[i]:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For each numerical feature, the `mean_` and `scale_` (standard deviation) from the `StandardScaler` are shown. These are used to standardize the features using the formula: `z = (x - mean) / scale`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Preprocessing Details: Categorical Features (OneHotEncoder)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "categorical_transformer_from_pipeline = preprocessor_from_pipeline.named_transformers_['cat']\n",
+    "# Original categorical features are stored in the ColumnTransformer's 'transformers_' list\n",
+    "original_categorical_features = [t[2] for t in preprocessor_from_pipeline.transformers if t[0] == 'cat'][0]\n",
+    "\n",
+    "print(\"Categorical Features OneHotEncoded:\", original_categorical_features)\n",
+    "\n",
+    "print(\"\\nOneHotEncoder Categories (for each original categorical feature):\")\n",
+    "for i, feature_name in enumerate(original_categorical_features):\n",
+    "    print(f\"Feature '{feature_name}': {categorical_transformer_from_pipeline.categories_[i]}\")\n",
+    "\n",
+    "print(\"\\nOutput feature names from OneHotEncoder (after dropping 'first'):\")\n",
+    "# These are the names of the columns generated by the OneHotEncoder\n",
+    "# The order matches the order of coefficients for the categorical part\n",
+    "ohe_feature_names = categorical_transformer_from_pipeline.get_feature_names_out(original_categorical_features)\n",
+    "print(ohe_feature_names)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For each categorical feature, `categories_` shows all unique categories found during training. \n",
+    "Since `drop='first'` was used in `OneHotEncoder`, the first category for each feature is dropped to avoid multicollinearity. The `get_feature_names_out()` method shows the names of the generated columns, implicitly indicating which categories were kept (and thus, which were dropped)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Detailed Example of `drop='first'` for JavaScript Implementation:\n",
+    "\n",
+    "Understanding how `drop='first'` affects the final features is crucial for the JavaScript implementation. Here's how it works for a couple of example features using the categories extracted from the training data:\n",
+    "\n",
+    "1.  **`gender`**:\n",
+    "    *   Original categories found by `OneHotEncoder` (from `categorical_transformer_from_pipeline.categories_[0]`): `['Female', 'Male', 'Other']` (order matters).\n",
+    "    *   `drop='first'` means 'Female' (the first in the list) is dropped as the reference category.\n",
+    "    *   The resulting features used in the model are `cat__gender_Male` and `cat__gender_Other`.\n",
+    "    *   **If input `gender` is 'Female'**: `cat__gender_Male` = 0, `cat__gender_Other` = 0.\n",
+    "    *   **If input `gender` is 'Male'**: `cat__gender_Male` = 1, `cat__gender_Other` = 0.\n",
+    "    *   **If input `gender` is 'Other'**: `cat__gender_Male` = 0, `cat__gender_Other` = 1.\n",
+    "\n",
+    "2.  **`diet_quality`**:\n",
+    "    *   Original categories found by `OneHotEncoder` (from `categorical_transformer_from_pipeline.categories_[2]` assuming it's the third categorical feature): `['Fair', 'Good', 'Poor']` (order matters).\n",
+    "    *   `drop='first'` means 'Fair' (the first in this list) is dropped.\n",
+    "    *   The resulting features are `cat__diet_quality_Good` and `cat__diet_quality_Poor`.\n",
+    "    *   **If input `diet_quality` is 'Fair'**: `cat__diet_quality_Good` = 0, `cat__diet_quality_Poor` = 0.\n",
+    "    *   **If input `diet_quality` is 'Good'**: `cat__diet_quality_Good` = 1, `cat__diet_quality_Poor` = 0.\n",
+    "    *   **If input `diet_quality` is 'Poor'**: `cat__diet_quality_Good` = 0, `cat__diet_quality_Poor` = 1.\n",
+    "\n",
+    "This logic needs to be replicated precisely in JavaScript: for each categorical input, determine which binary columns are generated and set them to 0 or 1 based on the input value and the dropped category for that feature. The order of categories shown by `categorical_transformer_from_pipeline.categories_` for each feature dictates which category is 'first'."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Python Example: Manual Prediction for a Single Instance\n",
+    "\n",
+    "This cell demonstrates how to manually calculate a prediction for a single raw input instance using the extracted model parameters. This serves as a Python counterpart to the JavaScript prediction logic, ensuring clarity on the transformation and calculation steps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "# 1. Sample Raw Input (same as used for JavaScript simulator testing)\n",
+    "sample_input = {\n",
+    "    'age': 20,\n",
+    "    'study_hours_per_day': 4.0,\n",
+    "    'social_media_hours': 2.0,\n",
+    "    'netflix_hours': 2.0,\n",
+    "    'attendance_percentage': 80,\n",
+    "    'sleep_hours': 7.0,\n",
+    "    'exercise_frequency': 3,\n",
+    "    'mental_health_rating': 5,\n",
+    "    'gender': 'Female',\n",
+    "    'part_time_job': 'No',\n",
+    "    'diet_quality': 'Fair',\n",
+    "    'parental_education_level': 'High School',\n",
+    "    'internet_quality': 'Average',\n",
+    "    'extracurricular_participation': 'No'\n",
+    "}\n",
+    "\n",
+    "print(f\"Sample Raw Input: {sample_input}\\n\")\n",
+    "\n",
+    "# 2. Use Extracted Model Parameters (ensure these variables are set from previous cells in the notebook execution flow)\n",
+    "# These variables are assumed to be populated from earlier cells where they were extracted from the pipeline.\n",
+    "intercept = lr_model.intercept_ \n",
+    "coefficients_list = lr_model.coef_\n",
+    "feature_names_ordered_by_coefs = preprocessor_from_pipeline.get_feature_names_out()\n",
+    "coefficients = dict(zip(feature_names_ordered_by_coefs, coefficients_list))\n",
+    "\n",
+    "num_transformer = preprocessor_from_pipeline.named_transformers_['num']\n",
+    "original_num_features_in_order = [t[2] for t in preprocessor_from_pipeline.transformers if t[0] == 'num'][0]\n",
+    "numerical_means = dict(zip(original_num_features_in_order, num_transformer.mean_))\n",
+    "numerical_std_devs = dict(zip(original_num_features_in_order, num_transformer.scale_))\n",
+    "\n",
+    "cat_transformer = preprocessor_from_pipeline.named_transformers_['cat']\n",
+    "original_cat_features_in_order = [t[2] for t in preprocessor_from_pipeline.transformers if t[0] == 'cat'][0]\n",
+    "ohe_categories_map = {}\n",
+    "for i, feature_name in enumerate(original_cat_features_in_order):\n",
+    "    ohe_categories_map[feature_name] = cat_transformer.categories_[i].tolist()\n",
+    "\n",
+    "print(\"--- Model Parameters Used (from previously executed cells) ---\")\n",
+    "print(f\"Intercept: {intercept}\")\n",
+    "print(f\"First 3 Coefficients: {{k: v for k, v in list(coefficients.items())[:3]}}\")\n",
+    "print(f\"Numerical Features (used by StandardScaler): {original_num_features_in_order}\")\n",
+    "print(f\"Numerical Means (first 3): {{k: v for k, v in list(numerical_means.items())[:3]}}\")\n",
+    "print(f\"Numerical Std Devs (first 3): {{k: v for k, v in list(numerical_std_devs.items())[:3]}}\")\n",
+    "print(f\"Categorical Features (used by OneHotEncoder): {original_cat_features_in_order}\")\n",
+    "print(f\"OHE Categories Map (e.g., gender): {{'gender': ohe_categories_map.get('gender')}}\")\n",
+    "print(f\"Final Feature Order for Coefficients (first 5): {list(feature_names_ordered_by_coefs[:5])}... Total: {len(feature_names_ordered_by_coefs)}\\n\")\n",
+    "\n",
+    "# 3. Manual Preprocessing for the Sample Input\n",
+    "processed_feature_values = {} # This will store the final values for each feature name in `feature_names_ordered_by_coefs`\n",
+    "\n",
+    "# a. Scale Numerical Features\n",
+    "print(\"--- Processing Numerical Features ---\")\n",
+    "for original_feature_name in original_num_features_in_order:\n",
+    "    raw_value = sample_input[original_feature_name]\n",
+    "    mean = numerical_means[original_feature_name]\n",
+    "    std_dev = numerical_std_devs[original_feature_name]\n",
+    "    scaled_value = (raw_value - mean) / std_dev\n",
+    "    # The final feature name for numerical features is 'num__' + original_feature_name\n",
+    "    final_num_feature_name = f\"num__{original_feature_name}\"\n",
+    "    processed_feature_values[final_num_feature_name] = scaled_value\n",
+    "    print(f\"Processed {final_num_feature_name}: ({raw_value} - {mean:.2f}) / {std_dev:.2f} = {scaled_value:.6f}\")\n",
+    "\n",
+    "# b. One-Hot Encode Categorical Features (respecting drop='first')\n",
+    "print(\"\\n--- Processing Categorical Features ---\")\n",
+    "for original_feature_name in original_cat_features_in_order:\n",
+    "    raw_value = sample_input[original_feature_name]\n",
+    "    categories_for_this_feature = ohe_categories_map[original_feature_name]\n",
+    "    dropped_category = categories_for_this_feature[0] # First category is dropped\n",
+    "    \n",
+    "    # Iterate through all categories found during training for this feature, *except* the dropped one\n",
+    "    for category_from_training in categories_for_this_feature[1:]:\n",
+    "        # The final feature name for OHE features is 'cat__' + original_feature_name + '_' + category_value\n",
+    "        final_ohe_feature_name = f\"cat__{original_feature_name}_{category_from_training}\"\n",
+    "        if raw_value == category_from_training:\n",
+    "            processed_feature_values[final_ohe_feature_name] = 1\n",
+    "        else:\n",
+    "            processed_feature_values[final_ohe_feature_name] = 0\n",
+    "        print(f\"Processed {final_ohe_feature_name}: (input '{raw_value}') -> {processed_feature_values[final_ohe_feature_name]}\")\n",
+    "    \n",
+    "    # If the raw_value was the dropped_category, all corresponding OHE features should be 0.\n",
+    "    # This is implicitly handled because only non-dropped categories generate feature names.\n",
+    "\n",
+    "# 4. Construct Final Feature Vector in Correct Order (as per feature_names_ordered_by_coefs)\n",
+    "feature_vector_for_prediction = []\n",
+    "print(\"\\n--- Constructing Final Feature Vector (in model's expected order) ---\")\n",
+    "for final_feature_name in feature_names_ordered_by_coefs:\n",
+    "    # If a feature was generated (e.g. cat__gender_Other) it will be in processed_feature_values.\n",
+    "    # If it was a dropped category (e.g. cat__gender_Female would not be a key), its effective value is 0\n",
+    "    # because its coefficient is not used / it's the base category.\n",
+    "    # The .get(final_feature_name, 0) handles cases where a OHE column might not be explicitly set if it's not active,\n",
+    "    # though the logic above should set all relevant OHE columns to 0 or 1.\n",
+    "    value_to_append = processed_feature_values.get(final_feature_name)\n",
+    "    if value_to_append is None:\n",
+    "        # This should ideally not happen if all features in feature_names_ordered_by_coefs are accounted for.\n",
+    "        # This could happen if a feature name from get_feature_names_out() was not created by our manual process.\n",
+    "        # For safety, we assume 0, but this indicates a potential mismatch if it occurs.\n",
+    "        print(f\"Warning: Feature {final_feature_name} not found in manually processed features. Using 0.\")\n",
+    "        value_to_append = 0 \n",
+    "    feature_vector_for_prediction.append(value_to_append)\n",
+    "\n",
+    "print(f\"Final Ordered Feature Vector (first 5 elements): {np.array(feature_vector_for_prediction[:5])}\")\n",
+    "print(f\"Full feature vector has {len(feature_vector_for_prediction)} elements.\")\n",
+    "\n",
+    "# 5. Calculate the Dot Product and Add Intercept\n",
+    "manual_prediction = intercept\n",
+    "for i, final_feature_name in enumerate(feature_names_ordered_by_coefs):\n",
+    "    manual_prediction += coefficients[final_feature_name] * feature_vector_for_prediction[i]\n",
+    "\n",
+    "# 6. Print Results\n",
+    "print(f\"\\nRaw Manual Prediction: {manual_prediction}\")\n",
+    "\n",
+    "# Clamp and round the prediction as in the JavaScript simulator\n",
+    "clamped_manual_prediction = max(0, min(100, manual_prediction))\n",
+    "rounded_manual_prediction = round(clamped_manual_prediction, 2)\n",
+    "print(f\"Clamped (0-100) and Rounded Manual Prediction: {rounded_manual_prediction}\")\n",
+    "\n",
+    "print(\"\\nThis manual calculation should match the JavaScript simulator's output for the same input, \\nand also the result from the 'Test Plan' step if the same input and parameters were used.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Final Check: All Preprocessed Feature Names in Order\n",
+    "\n",
+    "This list shows all feature names in the exact order they are fed into the linear regression model after all preprocessing. This order should match the order of the model's coefficients."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"All feature names from the preprocessor (in order):\")\n",
+    "all_processed_feature_names = preprocessor_from_pipeline.get_feature_names_out()\n",
+    "print(all_processed_feature_names)\n",
+    "\n",
+    "print(\"\\nNumber of coefficients:\", len(lr_model.coef_))\n",
+    "print(\"Number of preprocessed features:\", len(all_processed_feature_names))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Feature Selection and Preprocessing\n",
     "\n",
     "Based on EDA and HTML feature importance chart, let's select features. The HTML mentions:\n",


### PR DESCRIPTION
This commit introduces an interactive "What-If" simulator on the project's web page (docs/index.html).

Key changes:
- Added a new "Simulador" tab and section to `docs/index.html`.
- Implemented HTML input fields (sliders and dropdowns) for relevant student habits and characteristics.
- Developed JavaScript logic to:
    - Retrieve your inputs.
    - Apply scaling to numerical features (replicating StandardScaler).
    - Apply one-hot encoding to categorical features (replicating OneHotEncoder with drop='first').
    - Calculate a predicted exam score using coefficients from the trained Linear Regression model.
    - Display the prediction to you.
    - Update slider value displays dynamically.
- Updated `notebooks/04_Predictive_Modeling.ipynb` to:
    - Extract and clearly document the Linear Regression model's intercept, coefficients, feature order, numerical scaling parameters (means, std_devs), and categorical one-hot encoding scheme (categories, dropped categories).
    - Provide an explicit textual explanation of the one-hot encoding `drop='first'` logic with examples.
    - Include a Python code cell demonstrating a manual prediction for a sample instance, mirroring the JavaScript implementation, to serve as a reference.
- The simulator includes disclaimers regarding the use of a simplified Linear Regression model for web interactivity and potential differences from the more complex Random Forest model.

This feature enhances your engagement by allowing you to explore how different factors might hypothetically influence academic performance.